### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Run Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nilam576/my-blog-practice2/security/code-scanning/1](https://github.com/nilam576/my-blog-practice2/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the workflow's operations (e.g., checking out code). This change ensures that the workflow adheres to the principle of least privilege by restricting the `GITHUB_TOKEN` to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
